### PR TITLE
Add Support of lotsa.Time(duration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To run the operations spread over 4 threads for a fixed duration, use `lotsa.Tim
 ```go
 var total int64
 lotsa.Output = os.Stdout
-lotsa.Time(10 * time.Second, 4,
+lotsa.Time(23 * time.Millisecond, 4,
     func(_ *rand.Rand, thread int) {
         atomic.AddInt64(&total, 1)
     },
@@ -57,7 +57,7 @@ lotsa.Time(10 * time.Second, 4,
 Prints:
 
 ```
-655,352 ops over 4 threads in 24ms, 27,243,143/sec, 36 ns/op
+654,330 ops over 4 threads in 24ms, 27,207,775/sec, 36 ns/op
 ```
 
 ## Contact

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ Prints:
 1,000,000 ops over 4 threads in 23ms, 43,580,037/sec, 22 ns/op
 ```
 
+To run the operations spread over 4 threads for a fixed duration, use `lotsa.Time`
+
+```go
+var total int64
+lotsa.Output = os.Stdout
+lotsa.Time(10 * time.Second, 4,
+    func(_ *rand.Rand, thread int) {
+        atomic.AddInt64(&total, 1)
+    },
+)
+```
+
+Prints:
+
+```
+655,352 ops over 4 threads in 24ms, 27,243,143/sec, 36 ns/op
+```
+
 ## Contact
 
 Josh Baker [@tidwall](http://twitter.com/tidwall)

--- a/lotsa.go
+++ b/lotsa.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-// Output is used to print elased time and ops/sec
+// Output is used to print elapsed time and ops/sec
 var Output io.Writer
 
 // MemUsage is used to output the memory usage

--- a/lotsa_test.go
+++ b/lotsa_test.go
@@ -33,7 +33,7 @@ func TestTime(t *testing.T) {
 	})
 	actualDuration := time.Since(startTs)
 
-	if expectedDuration.Round(time.Millisecond) != actualDuration.Round(time.Millisecond) {
+	if expectedDuration.Round(time.Second) != actualDuration.Round(time.Second) {
 		t.Fatal("invalid duration")
 	}
 }

--- a/lotsa_test.go
+++ b/lotsa_test.go
@@ -1,11 +1,15 @@
 package lotsa
 
 import (
+	"math/rand"
+	"os"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestOps(t *testing.T) {
+	Output = os.Stdout
 	var threads = 4
 	var N = threads * 10000
 	var total int64
@@ -14,5 +18,22 @@ func TestOps(t *testing.T) {
 	})
 	if total != int64(N) {
 		t.Fatal("invalid total")
+	}
+}
+
+func TestTime(t *testing.T) {
+	Output = os.Stdout
+	var threads = 4
+	var expectedDuration = 1 * time.Millisecond
+	var total int64
+
+	startTs := time.Now()
+	Time(expectedDuration, threads, func(threadRand *rand.Rand, thread int) {
+		atomic.AddInt64(&total, 1)
+	})
+	actualDuration := time.Since(startTs)
+
+	if expectedDuration.Round(time.Millisecond) != actualDuration.Round(time.Millisecond) {
+		t.Fatal("invalid duration")
 	}
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] BUG
- [ ] Improvement
- [X] Documentation
- [X] Feature
- [X] Code Refactoring

## What this PR does / why we need it:
Adding support for `lotsa.Time(duration, threadCount, Op)`. 

This method runs `Op` for a fixed duration across a defined number of threads. 

This will be useful for benchmarking **ephemeral** data structures like Cache (maybe a combination of [btree](https://github.com/tidwall/btree) + [hwt](https://github.com/RussellLuo/timingwheel)), where we can measure the overall read throughput (OPS) when all the interfering operations (`Reads`, `Writes`, and `Prunes`) act.